### PR TITLE
Fix variable name bugs

### DIFF
--- a/lib/models/user-credential.js
+++ b/lib/models/user-credential.js
@@ -41,7 +41,7 @@ module.exports = function(UserCredential) {
     }
     var userCredentialModel = utils.getModel(this, UserCredential);
     var query = { provider: provider, externalId: profile.id };
-    query[userIdentity.relations.user.keyFrom]= user.id;
+    query[userCredentialModel.relations.user.keyFrom]= userId;
     userCredentialModel.findOne({ where: query }, function (err, extCredential) {
       if (err) {
         return cb(err);


### PR DESCRIPTION
Two variable names used to add the user id to the findOne query are invalid.
1. userIdentity is not a valid variable name. It should be userCredentialModel.
2. user is not a valid variable name. We can retrieve the user id from the userId argument.
